### PR TITLE
[Variable Parser] Specified Type Array

### DIFF
--- a/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
+++ b/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 		<Authors>Tetsu Otter</Authors>
 		<Company>Tech Otter</Company>
 		<Product>BIDS Project</Product>

--- a/BIDS.Parser.Variable/Utils/GetSpecifiedTypeArray.cs
+++ b/BIDS.Parser.Variable/Utils/GetSpecifiedTypeArray.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace BIDS.Parser.Variable;
+
+public static partial class Utils
+{
+	static public Array? GetSpecifiedTypeArray(this VariableDataType type, long length)
+		=> type switch
+		{
+			VariableDataType.Boolean => new bool[length],
+
+			VariableDataType.Int8 => new sbyte[length],
+			VariableDataType.Int16 => new short[length],
+			VariableDataType.Int32 => new int[length],
+			VariableDataType.Int64 => new long[length],
+
+			VariableDataType.UInt8 => new byte[length],
+			VariableDataType.UInt16 => new ushort[length],
+			VariableDataType.UInt32 => new uint[length],
+			VariableDataType.UInt64 => new ulong[length],
+
+			VariableDataType.Float16 => new Half[length],
+			VariableDataType.Float32 => new float[length],
+			VariableDataType.Float64 => new double[length],
+
+			_ => null
+		};
+}

--- a/BIDS.Parser.Variable/VariableStructure/VariableStructure.ArrayStructure.cs
+++ b/BIDS.Parser.Variable/VariableStructure/VariableStructure.ArrayStructure.cs
@@ -25,9 +25,11 @@ public partial record VariableStructure
 				};
 			}
 
-			object?[] array = new object?[arrayLength];
+			if (ElemType.GetSpecifiedTypeArray(arrayLength) is not Array array)
+				throw new Exception($"Cannot create array with type {ElemType}");
+
 			for (int i = 0; i < arrayLength; i++)
-				array[i] = this.ElemType.GetValueAndMoveNext(ref bytes);
+				array.SetValue(this.ElemType.GetValueAndMoveNext(ref bytes), i);
 
 			return this with
 			{


### PR DESCRIPTION
`VariableStructure.ArrayStructure`について、`object[]`だと、例えば`int[]`なフィールド等に`SetValue`できない。
そこで、それぞれにあわせた配列を作成してそれに値を書き込んでいくことで、正常に代入を行えるようにした。

なお、現状配列の値書き込みパフォーマンスについて、以下の問題を抱えている。
- `Array.SetValue`の使用 (要ベンチマーク)
- 書き込む値を`ReadOnlySpan<byte>`から取り出して変換する際に、１要素ごとに型の識別を行なっている (最初の1回で十分なはず)

この点については、後日対応とする