### PR TITLE
Variable Parser Support NetStandard2.1

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -39,9 +39,9 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Install dependencies
-        run: dotnet restore ${{ matrix.project }}
+        run: dotnet restore ${{ matrix.project }} -nowarn:NETSDK1138
 
       - name: Build ${{ matrix.project }}
-        run: dotnet build ${{ matrix.project }} -c Release --no-restore -f ${{ matrix.framework }}
+        run: dotnet build ${{ matrix.project }} -c Release --no-restore -f ${{ matrix.framework }} -nowarn:NETSDK1138
       - name: Test ${{ matrix.project }}
         run: dotnet test ${{ matrix.project }} -c Release --no-build -v normal -f ${{ matrix.framework }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,45 @@
+name: Unit Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        dotnet-version:
+          - '6.0.x'
+        project:
+          - BIDS.Parser.Tests
+          - BIDS.Parser.Variable.Tests
+        framework:
+          - net6.0
+        include:
+          - project: BIDS.Parser.Variable.Tests
+            framework: netcoreapp3.0
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Install dependencies
+        run: dotnet restore ${{ matrix.project }}
+
+      - name: Build ${{ matrix.project }}
+        run: dotnet build ${{ matrix.project }} -c Release --no-restore -f ${{ matrix.framework }}
+      - name: Test ${{ matrix.project }}
+        run: dotnet test ${{ matrix.project }} -c Release --no-build -v normal -f ${{ matrix.framework }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,13 +16,13 @@ jobs:
 
     strategy:
       matrix:
+        project:
+          - BIDS.Parser.Tests
+          - BIDS.Parser.Variable.Tests
         os:
           - ubuntu-latest
         dotnet-version:
           - '6.0.x'
-        project:
-          - BIDS.Parser.Tests
-          - BIDS.Parser.Variable.Tests
         framework:
           - net6.0
         include:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,6 +27,8 @@ jobs:
           - net6.0
         include:
           - project: BIDS.Parser.Variable.Tests
+            os: ubuntu-latest
+            dotnet-version: '6.0.x'
             framework: netcoreapp3.0
     steps:
       - uses: actions/checkout@v3

--- a/BIDS.Parser.Variable.Tests/BIDS.Parser.Variable.Tests.csproj
+++ b/BIDS.Parser.Variable.Tests/BIDS.Parser.Variable.Tests.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;netcoreapp3.0</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/BIDS.Parser.Variable.Tests/UtilsTests/MemberInfoToVariableDataRecordListTests.cs
+++ b/BIDS.Parser.Variable.Tests/UtilsTests/MemberInfoToVariableDataRecordListTests.cs
@@ -7,7 +7,7 @@ public class MemberInfoToVariableDataRecordListTests
 	class SampleBaseClass
 	{
 		public int SampleBaseIntProperty { get; }
-		public long SampleBaseLongField;
+		public long SampleBaseLongField = 0;
 
 		private int PrivateBaseIntProperty { get; }
 		protected string ProtectedBaseStringField = string.Empty;
@@ -16,7 +16,7 @@ public class MemberInfoToVariableDataRecordListTests
 		public event EventHandler? BasePublicEvent;
 		private event EventHandler? BasePrivateEvent;
 
-		public void BasePublicMethod() => BasePrivateEvent?.Invoke(this, new());
+		public void BasePublicMethod() => BasePublicEvent?.Invoke(this, new());
 		private void BasePrivateMethod() => BasePrivateEvent?.Invoke(this, new());
 
 		static public byte PublicBaseStaticCharProperty { get; }
@@ -25,7 +25,7 @@ public class MemberInfoToVariableDataRecordListTests
 	class SampleClass : SampleBaseClass
 	{
 		public int SampleIntProperty { get; }
-		public long[]? SampleLongArrayField;
+		public long[]? SampleLongArrayField = Array.Empty<long>();
 
 		private int PrivateIntProperty { get; }
 		protected string ProtectedStringField = string.Empty;

--- a/BIDS.Parser.Variable.Tests/UtilsTests/TypeToVariableDataTypeTests.cs
+++ b/BIDS.Parser.Variable.Tests/UtilsTests/TypeToVariableDataTypeTests.cs
@@ -13,7 +13,9 @@ public class TypeToVariableDataTypeTests
 	[TestCase(typeof(ulong), VariableDataType.UInt64)]
 	[TestCase(typeof(float), VariableDataType.Float32)]
 	[TestCase(typeof(double), VariableDataType.Float64)]
+#if NET5_0_OR_GREATER
 	[TestCase(typeof(Half), VariableDataType.Float16)]
+#endif
 	[TestCase(typeof(string), VariableDataType.Array)]
 	[TestCase(typeof(object[]), VariableDataType.Array)]
 	public void NormalCaseTests(Type type, VariableDataType expectedVariableDataType)

--- a/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
+++ b/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<Version>1.2.0</Version>
 		<Authors>Tetsu Otter</Authors>

--- a/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
+++ b/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
-		<Version>1.2.0</Version>
+		<Version>1.2.1</Version>
 		<Authors>Tetsu Otter</Authors>
 		<Company>Tech Otter</Company>
 		<Product>BIDS Project</Product>

--- a/BIDS.Parser.Variable/IsExternalInitAttribute.cs
+++ b/BIDS.Parser.Variable/IsExternalInitAttribute.cs
@@ -1,0 +1,5 @@
+namespace System.Runtime.CompilerServices;
+
+#if !NET5_0_OR_GREATER
+public class IsExternalInit { }
+#endif

--- a/BIDS.Parser.Variable/Utils/GetSpecifiedTypeArray.cs
+++ b/BIDS.Parser.Variable/Utils/GetSpecifiedTypeArray.cs
@@ -19,7 +19,9 @@ public static partial class Utils
 			VariableDataType.UInt32 => new uint[length],
 			VariableDataType.UInt64 => new ulong[length],
 
+#if NET5_0_OR_GREATER
 			VariableDataType.Float16 => new Half[length],
+#endif
 			VariableDataType.Float32 => new float[length],
 			VariableDataType.Float64 => new double[length],
 

--- a/BIDS.Parser.Variable/Utils/Span.GetValueAndMove.cs
+++ b/BIDS.Parser.Variable/Utils/Span.GetValueAndMove.cs
@@ -89,12 +89,14 @@ public static partial class Utils
 	#endregion
 
 	#region Floating Point Number
+#if NET5_0_OR_GREATER
 	static public System.Half GetFloat16AndMove(ref ReadOnlySpan<byte> span)
 	{
 		var v = BitConverter.ToHalf(span[..2]);
 		span = span[2..];
 		return v;
 	}
+#endif
 
 	static public float GetFloat32AndMove(ref ReadOnlySpan<byte> span)
 	{

--- a/BIDS.Parser.Variable/Utils/TypeToVariableDataType.cs
+++ b/BIDS.Parser.Variable/Utils/TypeToVariableDataType.cs
@@ -31,7 +31,9 @@ public static partial class Utils
 				TypeCode.Single => VariableDataType.Float32,
 				TypeCode.Double => VariableDataType.Float64,
 
+#if NET5_0_OR_GREATER
 				TypeCode.Object when type == typeof(Half) => VariableDataType.Float16,
+#endif
 
 				TypeCode.String => VariableDataType.Array,
 

--- a/BIDS.Parser.Variable/Utils/VariableDataTypeExtensions.cs
+++ b/BIDS.Parser.Variable/Utils/VariableDataTypeExtensions.cs
@@ -19,7 +19,9 @@ public static partial class Utils
 			VariableDataType.UInt32 => Utils.GetUInt32AndMove(ref bytes),
 			VariableDataType.UInt64 => Utils.GetUInt64AndMove(ref bytes),
 
+#if NET5_0_OR_GREATER
 			VariableDataType.Float16 => Utils.GetFloat16AndMove(ref bytes),
+#endif
 			VariableDataType.Float32 => Utils.GetFloat32AndMove(ref bytes),
 			VariableDataType.Float64 => Utils.GetFloat64AndMove(ref bytes),
 
@@ -41,7 +43,9 @@ public static partial class Utils
 			VariableDataType.UInt32 => BitConverter.GetBytes((uint)(obj ?? 0)),
 			VariableDataType.UInt64 => BitConverter.GetBytes((ulong)(obj ?? 0)),
 
+#if NET5_0_OR_GREATER
 			VariableDataType.Float16 => BitConverter.GetBytes((Half)(obj ?? default(Half))),
+#endif
 			VariableDataType.Float32 => BitConverter.GetBytes((float)(obj ?? 0)),
 			VariableDataType.Float64 => BitConverter.GetBytes((double)(obj ?? 0)),
 

--- a/BIDS.Parser/BIDS.Parser.csproj
+++ b/BIDS.Parser/BIDS.Parser.csproj
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 		<Version>1.2.0</Version>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\BIDS.Parser.Variable\BIDS.Parser.Variable.csproj" />
-  </ItemGroup>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\BIDS.Parser.Variable\BIDS.Parser.Variable.csproj" />
+	</ItemGroup>
 </Project>

--- a/BIDS.Parser/BIDS.Parser.csproj
+++ b/BIDS.Parser/BIDS.Parser.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 		<Version>1.2.0</Version>

--- a/BIDS.Parser/BIDS.Parser.csproj
+++ b/BIDS.Parser/BIDS.Parser.csproj
@@ -5,7 +5,7 @@
 		<LangVersion>10.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.2.0</Version>
+		<Version>1.2.1</Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\BIDS.Parser.Variable\BIDS.Parser.Variable.csproj" />

--- a/BIDS.Parser/Parser.ControlKey.cs
+++ b/BIDS.Parser/Parser.ControlKey.cs
@@ -12,7 +12,7 @@ public record BIDSCmd_KeyControl(
 		{
 			KeyControlType.Pressed => 'P',
 			KeyControlType.Released => 'R',
-			_ => throw new NotSupportedException($"{ToCommandStr} Method is not supported when the value of {this.ControlType} is {KeyControlType.Unknown}")
+			_ => throw new NotSupportedException($"{nameof(ToCommandStr)} Method is not supported when the value of {this.ControlType} is {KeyControlType.Unknown}")
 		});
 }
 

--- a/BIDS.Parser/Parser.Reverser.cs
+++ b/BIDS.Parser/Parser.Reverser.cs
@@ -13,7 +13,7 @@ public record BIDSCmd_ReverserControl(
 			ReverserPos.Forward => "F",
 			ReverserPos.Neutral => "N",
 			ReverserPos.Backward => "B",
-			_ => throw new NotSupportedException($"{ToCommandStr} Method is not supported when the value of {ReverserPos} is {ReverserPos.Unknown}")
+			_ => throw new NotSupportedException($"{nameof(ToCommandStr)} Method is not supported when the value of {ReverserPos} is {ReverserPos.Unknown}")
 		});
 }
 

--- a/BIDS_Server/Program.PrintSelectableModList.cs
+++ b/BIDS_Server/Program.PrintSelectableModList.cs
@@ -12,7 +12,6 @@ partial class Program
 			string[] fs = LSMod();
 			if (fs?.Length > 0)
 			{
-				int i = 0;
 				foreach (var v in fs)
 				{
 					string[] cn = v.Split('.');


### PR DESCRIPTION
`TR.CustomDataSharingManager`のVariable対応を実装するにあたり、DllExportの制約上`net6.0`を使用できないため、`BIDS.Parser.Variable`を`netstandard2.1`にて参照できるようにした。

なお、`System.Half`が`net5.0`から対応であるため、`if NET5_0_OR_GREATER`によるスイッチを使用して`netstandard2.1`には含めないようにしている。